### PR TITLE
test: add Xquik OpenAPI 3.1 fixture

### DIFF
--- a/tests/QuickMCP.Tests/McpServerInfoBuilderTests.cs
+++ b/tests/QuickMCP.Tests/McpServerInfoBuilderTests.cs
@@ -35,6 +35,7 @@ public class McpServerInfoBuilderTests
     [InlineData("recraft.yaml","https://example.com/")]
     [InlineData("luma.yaml","https://example.com/")]
     [InlineData("maven.json","https://example.com/")]
+    [InlineData("xquik.json","https://xquik.com/")]
     public async Task OpenApiTest(string fileName,string baseUrl)
     {
         var path = $"specs/{fileName}";

--- a/tests/QuickMCP.Tests/QuickMCP.Tests.csproj
+++ b/tests/QuickMCP.Tests/QuickMCP.Tests.csproj
@@ -127,6 +127,9 @@
       <None Update="specs\maven.json">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </None>
+      <None Update="specs\xquik.json">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
     </ItemGroup>
 
     <ItemGroup>

--- a/tests/QuickMCP.Tests/specs/xquik.json
+++ b/tests/QuickMCP.Tests/specs/xquik.json
@@ -1,0 +1,235 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Xquik API",
+    "version": "1.0",
+    "description": "Public fixture for authenticated X data and composition endpoints."
+  },
+  "servers": [
+    {
+      "url": "https://xquik.com"
+    }
+  ],
+  "security": [
+    {
+      "apiKey": []
+    },
+    {
+      "oauthBearer": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Tweets"
+    },
+    {
+      "name": "Users"
+    },
+    {
+      "name": "Composition"
+    }
+  ],
+  "paths": {
+    "/api/v1/x/tweets/search": {
+      "get": {
+        "operationId": "searchTweets",
+        "summary": "Search tweets",
+        "tags": [
+          "Tweets"
+        ],
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Search results",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TweetSearchResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/x/users/{id}": {
+      "get": {
+        "operationId": "getUser",
+        "summary": "Get user profile",
+        "tags": [
+          "Users"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "User profile",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/compose": {
+      "post": {
+        "operationId": "compose",
+        "summary": "Compose, refine, or score a tweet",
+        "tags": [
+          "Composition"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ComposeRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Composition result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ComposeResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "apiKey": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "x-api-key"
+      },
+      "oauthBearer": {
+        "type": "http",
+        "scheme": "bearer"
+      }
+    },
+    "schemas": {
+      "Tweet": {
+        "type": "object",
+        "required": [
+          "id",
+          "text"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "text": {
+            "type": "string"
+          },
+          "authorUsername": {
+            "type": "string"
+          }
+        }
+      },
+      "TweetSearchResponse": {
+        "type": "object",
+        "required": [
+          "tweets"
+        ],
+        "properties": {
+          "tweets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Tweet"
+            }
+          }
+        }
+      },
+      "User": {
+        "type": "object",
+        "required": [
+          "id",
+          "username"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "username": {
+            "type": "string"
+          },
+          "followersCount": {
+            "type": "integer"
+          }
+        }
+      },
+      "ComposeRequest": {
+        "type": "object",
+        "required": [
+          "prompt"
+        ],
+        "properties": {
+          "prompt": {
+            "type": "string"
+          },
+          "mode": {
+            "type": "string",
+            "enum": [
+              "compose",
+              "refine",
+              "score"
+            ]
+          }
+        }
+      },
+      "ComposeResponse": {
+        "type": "object",
+        "required": [
+          "text"
+        ],
+        "properties": {
+          "text": {
+            "type": "string"
+          },
+          "score": {
+            "type": "number"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Summary:
- Add a compact Xquik OpenAPI 3.1 fixture covering apiKey and bearer security, query and path parameters, and a JSON request body.
- Include the fixture in the existing OpenAPI builder data set so it exercises OpenAPI 3.1 down-conversion.

Validation:
- jq empty tests/QuickMCP.Tests/specs/xquik.json
- git diff --check
- Not run: dotnet test because dotnet is not installed in this local environment.